### PR TITLE
Enable web platform for Expo preview builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "jsEngine": "hermes",
-    "platforms": ["ios", "android"],
+    "platforms": ["ios", "android", "web"],
     "assetBundlePatterns": ["**/*"],
     "runtimeVersion": { "policy": "appVersion" },
     "updates": {


### PR DESCRIPTION
## Summary
- include web in Expo platforms so preview exports succeed

## Testing
- `npm test`
- `npx expo export:web` *(fails: TypeError fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0948e3094832e827d6938f35b71a9