### PR TITLE
feat: toggle violence and guide to nearest civ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ function Root() {
     { key: 'random',    label: 'Random',    onPress: () => sceneRef.current?.focusRandom() },
   ];
   const [paused, setPaused] = useState(false);
+  const [violent, setViolent] = useState(true);
   if (!engineRef.current) engineRef.current = new Engine({ ...params } as unknown as EngineParams, Math.floor(Math.random()*1e9));
 
   return (
@@ -72,6 +73,17 @@ function Root() {
           }}
         >
           <Text style={styles.toolText}>{paused ? 'Resume' : 'Pause'}</Text>
+        </Pressable>
+        <Pressable
+          style={styles.toolButton}
+          onPress={() => {
+            if (engineRef.current) {
+              engineRef.current.violence = !engineRef.current.violence;
+              setViolent(engineRef.current.violence);
+            }
+          }}
+        >
+          <Text style={styles.toolText}>{violent ? 'Violence On' : 'Violence Off'}</Text>
         </Pressable>
         <Pressable style={styles.toolButton} onPress={() => engineRef.current?.reset()}>
           <Text style={styles.toolText}>Reset</Text>

--- a/src/sim/engine.ts
+++ b/src/sim/engine.ts
@@ -23,6 +23,7 @@ export class Engine {
   revealsB = 0; revealsS = 0; revealsR = 0;
   killsThisStep = 0; totalKills = 0;
   paused = false;
+  violence = true;
 
   constructor(params:EngineParams, seed:number){
     this.params = params;
@@ -104,7 +105,7 @@ export class Engine {
       for(let j=0;j<this.civCount;j++) if(i!==j && this.civAlive[j]){
         if(this.detect(i,j)){
           this.revealsS++;
-          this.kill(i,j);
+          if (this.violence) this.kill(i,j);
         }
       }
     }

--- a/src/ui/MiniMap.tsx
+++ b/src/ui/MiniMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import Svg, { Circle, Line, Rect } from 'react-native-svg';
+import Svg, { Circle, Line, Rect, Path } from 'react-native-svg';
 
 type XY = [number, number];
 
@@ -20,13 +20,23 @@ export const MiniMap: React.FC<Props> = ({ radius, cameraPos, civXY, size = 140,
   const worldToMap = (x: number, z: number) => ({ x: r + x * s, y: r + z * s });
   const mapToWorld = (mx: number, my: number) => ({ x: (mx - r) / s, z: (my - r) / s });
 
+  let nearest = -1;
+  let nd2 = Infinity;
+  for (let i = 0; i < civXY.length; i++) {
+    const dx = civXY[i][0] - cameraPos.x;
+    const dz = civXY[i][1] - cameraPos.z;
+    const d2 = dx * dx + dz * dz;
+    if (d2 < nd2) { nd2 = d2; nearest = i; }
+  }
+
   return (
     <View style={{ width: size, height: size }}>
       <Svg width={size} height={size}>
         <Circle cx={r} cy={r} r={r - 1} stroke="#5872b8" strokeWidth={1} fill="rgba(16,22,43,0.6)" />
         {civXY.map(([x, z], i) => {
           const p = worldToMap(x, z);
-          return <Circle key={i} cx={p.x} cy={p.y} r={1.6} fill="#9cc8ff" />;
+          const isN = i === nearest;
+          return <Circle key={i} cx={p.x} cy={p.y} r={isN ? 2.5 : 1.6} fill={isN ? '#ff6b6b' : '#9cc8ff'} />;
         })}
         {(() => {
           const p = worldToMap(cameraPos.x, cameraPos.z);
@@ -37,6 +47,24 @@ export const MiniMap: React.FC<Props> = ({ radius, cameraPos, civXY, size = 140,
             <>
               <Circle cx={p.x} cy={p.y} r={3.5} fill="#ffd166" />
               <Line x1={p.x} y1={p.y} x2={p.x + hx} y2={p.y + hz} stroke="#ffd166" strokeWidth={2} />
+            </>
+          );
+        })()}
+        {nearest >= 0 && (() => {
+          const cam = worldToMap(cameraPos.x, cameraPos.z);
+          const target = worldToMap(civXY[nearest][0], civXY[nearest][1]);
+          const angle = Math.atan2(target.y - cam.y, target.x - cam.x);
+          const ah = 6;
+          const bx = target.x - Math.cos(angle) * ah;
+          const by = target.y - Math.sin(angle) * ah;
+          const lx = bx + Math.cos(angle + Math.PI / 2) * (ah * 0.5);
+          const ly = by + Math.sin(angle + Math.PI / 2) * (ah * 0.5);
+          const rx = bx + Math.cos(angle - Math.PI / 2) * (ah * 0.5);
+          const ry = by + Math.sin(angle - Math.PI / 2) * (ah * 0.5);
+          return (
+            <>
+              <Line x1={cam.x} y1={cam.y} x2={target.x} y2={target.y} stroke="#ff6b6b" strokeWidth={1.5} />
+              <Path d={`M ${target.x} ${target.y} L ${lx} ${ly} L ${rx} ${ry} Z`} fill="#ff6b6b" />
             </>
           );
         })()}


### PR DESCRIPTION
## Summary
- add simulation violence toggle to pause killings
- highlight and point to nearest civilization on minimap

## Testing
- `npm run typecheck`
- `npx expo start -c` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a14a9ce32c832ea1c2516673ce86dc