### PR TITLE
fix: simplify civ focus to random

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,12 +19,8 @@ function Root() {
   const engineRef = useRef<Engine | null>(null);
   const sceneRef = useRef<GLSceneHandle>(null);
   const items = [
-    { key: 'home',      label: 'Home',      onPress: () => sceneRef.current?.home() },
-    { key: 'strong',    label: 'Strongest', onPress: () => sceneRef.current?.focusStrongest() },
-    { key: 'frontier',  label: 'Frontier',  onPress: () => sceneRef.current?.focusFrontier() },
-    { key: 'densest',   label: 'Densest',   onPress: () => sceneRef.current?.focusDensest() },
-    { key: 'nearest',   label: 'Nearest',   onPress: () => sceneRef.current?.focusNearest() },
-    { key: 'random',    label: 'Random',    onPress: () => sceneRef.current?.focusRandom() },
+    { key: 'home',   label: 'Home',       onPress: () => sceneRef.current?.home() },
+    { key: 'random', label: 'Random Civ', onPress: () => sceneRef.current?.focusRandom() },
   ];
   const [paused, setPaused] = useState(false);
   const [violent, setViolent] = useState(true);


### PR DESCRIPTION
## Summary
- reduce POI bar to Home and Random Civ buttons

## Perf note
- no measurable impact; removed unused UI calls

## Verification
- `npm run typecheck`
- `npx expo start -c` *(fails: fetch failed)*

## Risk
- low: UI array change only


------
https://chatgpt.com/codex/tasks/task_e_68a1eacc8438832eb2cf7da2727e4347