### PR TITLE
feat: visible cosmos (parallax stars + nebula), reliable random focus, off-screen pointer, auto-seed, safer focus distance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,19 @@ function Root() {
   const sceneRef = useRef<GLSceneHandle>(null);
   const items = [
     { key: 'home',   label: 'Home',       onPress: () => sceneRef.current?.home() },
-    { key: 'random', label: 'Random Civ', onPress: () => sceneRef.current?.focusRandom() },
+    { key: 'random', label: 'Random Civ', onPress: () => {
+        const e = engineRef.current!;
+        if (typeof e.spawnRandomCiv === 'function') {
+          let any = false; const n = e.civCount ?? 0;
+          for (let i = 0; i < n; i++) {
+            // @ts-ignore
+            if (e.civAlive?.[i] || e.isCivAlive?.(i)) { any = true; break; }
+          }
+          if (!any) e.spawnRandomCiv();
+        }
+        sceneRef.current?.focusRandom();
+      }
+    },
   ];
   const [paused, setPaused] = useState(false);
   const [violent, setViolent] = useState(true);

--- a/src/ui/EdgePointer.tsx
+++ b/src/ui/EdgePointer.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { G, Circle, Path } from 'react-native-svg';
+
+type Props = {
+  show: boolean;
+  x: number;  // px in parent view
+  y: number;  // px in parent view
+  angleDeg: number; // 0=right, 90=down
+  label?: string;
+};
+
+export const EdgePointer: React.FC<Props> = ({ show, x, y, angleDeg }) => {
+  if (!show) return null;
+  const s = 28, c = s / 2;
+  return (
+    <View pointerEvents="none" style={[styles.wrap, { left: x - c, top: y - c, width: s, height: s }]}>
+      <Svg width={s} height={s}>
+        <G rotation={angleDeg} origin={`${c}, ${c}`}>
+          <Circle cx={c} cy={c} r={c - 1.5} stroke="#87a5ff" strokeOpacity={0.7} strokeWidth={1.5} fill="rgba(10,15,30,0.55)" />
+          <Path d={`M ${c + 9} ${c} L ${c + 1.8} ${c - 5.4} L ${c + 1.8} ${c + 5.4} Z`}
+                fill="#ffd36e" stroke="#3b2f00" strokeOpacity={0.35} strokeWidth={0.6}/>
+        </G>
+      </Svg>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: { position: 'absolute' },
+});
+


### PR DESCRIPTION
## Summary
- add EdgePointer UI overlay for off-screen civs
- ensure engine exposes spawnRandomStars and spawnRandomCiv helpers with polyfills
- auto-seed world, parallax background, safer focus, and random civ spawn/focus improvements

## Testing
- `npm run typecheck`
- `npx expo start -c` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a200a3f65c832e826f504eca2485aa