### PR TITLE
feat: make background transparent for star debug

### DIFF
--- a/src/gl/Scene.tsx
+++ b/src/gl/Scene.tsx
@@ -208,8 +208,9 @@ export const GLScene = React.forwardRef<GLSceneHandle, Props>(function GLScene(
     camera.far = Math.max(camera.far, 1e9);
     camera.updateProjectionMatrix();
 
-    // optional: set clear color to deep space
-    rendererRef.current?.renderer.setClearColor(0x000006, 1);
+    // optional: set clear color to deep space but keep it transparent so we can
+    // confirm nothing else is overdrawing the stars
+    rendererRef.current?.renderer.setClearColor(0x000006, 0);
 
     // place the camera so the real cluster is visible on boot
     const world = getWorld();

--- a/src/gl/renderer3d.ts
+++ b/src/gl/renderer3d.ts
@@ -233,7 +233,9 @@ export function initRenderer(gl: any, opts: InitOpts): RendererHandle {
   rendererRef.current = { renderer, pr };
 
   const scene = new THREE.Scene();
-  scene.background = new THREE.Color("#02050c");
+  // Render against the underlying view color so we can verify the star field
+  // isn't hidden by an opaque clear.
+  scene.background = null;
 
   const camera = new THREE.PerspectiveCamera(
     60,


### PR DESCRIPTION
## Summary
- render scene with transparent background so underlying color shows through
- set clear color alpha 0 to verify stars aren't hidden by an opaque overlay

## Testing
- `npm run typecheck`
- `npx expo start -c` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a25ad4aa80832e92317661260eb790