### PR TITLE
fix: delay GL init until layout

### DIFF
--- a/src/gl/Scene.tsx
+++ b/src/gl/Scene.tsx
@@ -5,9 +5,11 @@ import React, {
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import { View, PixelRatio, LayoutChangeEvent } from "react-native";
 import { GLView } from "expo-gl";
+import type { ExpoWebGLRenderingContext } from "expo-gl";
 import * as THREE from "three";
 import { GestureDetector } from "react-native-gesture-handler";
 
@@ -21,6 +23,8 @@ import { initRenderer } from "./renderer3d";
 import type { CameraState, RaycastRefs } from "./types";
 import { createStarsMesh } from "./StarsMesh";
 import { getWorld } from "../sim/world";
+
+const DEBUG_FORCE_VISIBLE = __DEV__ && true; // set to false to disable
 
 // Public API for parent components
 export type GLSceneHandle = {
@@ -73,21 +77,35 @@ export const GLScene = React.forwardRef<GLSceneHandle, Props>(function GLScene(
     pr: number;
   } | null>(null);
   const viewSize = useRef({ w: 1, h: 1, pr: PixelRatio.get() });
+
+  // Debug refs and layout state for forced-visible scene
+  const glDebugRef = useRef<ExpoWebGLRenderingContext | null>(null);
+  const debugRendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const debugCameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const [vw, setVw] = useState(0);
+  const [vh, setVh] = useState(0);
+
   const onLayout = (e: LayoutChangeEvent) => {
     const { width, height } = e.nativeEvent.layout;
-    viewSize.current.w = width;
-    viewSize.current.h = height;
-    const r = rendererRef.current;
-    if (r?.renderer) {
-      r.renderer.setSize(
-        Math.max(1, Math.floor(width * r.pr)),
-        Math.max(1, Math.floor(height * r.pr)),
-        false
-      );
-      // keep aspect/fov in sync
-      if (threeRefs.current.camera) {
-        threeRefs.current.camera.aspect = width / height;
-        threeRefs.current.camera.updateProjectionMatrix();
+    if (width && height) {
+      const w = Math.floor(width);
+      const h = Math.floor(height);
+      setVw(w);
+      setVh(h);
+      viewSize.current.w = width;
+      viewSize.current.h = height;
+      const r = rendererRef.current;
+      if (r?.renderer) {
+        r.renderer.setSize(
+          Math.max(1, Math.floor(width * r.pr)),
+          Math.max(1, Math.floor(height * r.pr)),
+          false
+        );
+        // keep aspect/fov in sync
+        if (threeRefs.current.camera) {
+          threeRefs.current.camera.aspect = width / height;
+          threeRefs.current.camera.updateProjectionMatrix();
+        }
       }
     }
   };
@@ -185,6 +203,21 @@ export const GLScene = React.forwardRef<GLSceneHandle, Props>(function GLScene(
     lookAt.current.set(0, 0, 0);
   }, [engine]);
 
+  // When RN layout changes, keep debug renderer in sync
+  useEffect(() => {
+    const gl = glDebugRef.current;
+    const renderer = debugRendererRef.current;
+    const camera = debugCameraRef.current;
+    if (!gl || !renderer || !camera || vw <= 0 || vh <= 0) return;
+
+    const dpr = PixelRatio.get();
+    const width = Math.max(1, Math.floor(vw * dpr));
+    const height = Math.max(1, Math.floor(vh * dpr));
+    renderer.setSize(width, height, false);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  }, [vw, vh]);
+
   // NEW: ensure stars are created from the actual sim and added to the scene
   const ensureSimStars = useCallback(() => {
     const { scene, camera } = threeRefs.current;
@@ -223,30 +256,153 @@ export const GLScene = React.forwardRef<GLSceneHandle, Props>(function GLScene(
   return (
     <GestureDetector gesture={gesture}>
       <View style={{ flex: 1, position: "relative" }} onLayout={onLayout}>
-        <GLView
-          style={{ flex: 1 }}
-          onContextCreate={(gl) => {
-            rendererHandle.current = initRenderer(gl, {
-              engine,
-              maxStars,
-              maxCivs,
-              cam,
-              lookAt,
-              focusTween,
-              stickL,
-              stickR,
-              overlay,
-              threeRefs,
-              onFps,
-              rendererRef,
-            });
+        {vw > 0 && vh > 0 && (
+          <GLView
+            style={{ flex: 1 }}
+            onContextCreate={(gl) => {
+              glDebugRef.current = gl;
 
-            // After renderer+scene+camera exist, attach the real-sim stars
-            // (initRenderer should populate threeRefs.current.scene/camera)
-            // We defer to the next tick to ensure they're set.
-            setTimeout(ensureSimStars, 0);
-          }}
-        />
+              if (DEBUG_FORCE_VISIBLE) {
+                // Use RN layout as ground truth; fall back to drawingBuffer if available
+                const dpr = PixelRatio.get();
+                const width =
+                  gl.drawingBufferWidth || Math.max(1, Math.floor(vw * dpr));
+                const height =
+                  gl.drawingBufferHeight || Math.max(1, Math.floor(vh * dpr));
+
+                // Provide "canvas" shim for three on RN
+                const canvas: any = {
+                  width,
+                  height,
+                  style: {},
+                  clientWidth: width,
+                  clientHeight: height,
+                  addEventListener: () => {},
+                  removeEventListener: () => {},
+                  getContext: () => gl,
+                };
+
+                const renderer = new THREE.WebGLRenderer({
+                  context: gl as any,
+                  canvas,
+                  alpha: false,
+                  antialias: false,
+                  premultipliedAlpha: false,
+                  preserveDrawingBuffer: false,
+                  powerPreference: "high-performance",
+                  // @ts-expect-error RN/Expo specific
+                  contextAttributes: (gl as any).getContextAttributes?.(),
+                });
+                renderer.setPixelRatio(dpr);
+                renderer.setSize(width, height, false);
+                renderer.setClearColor(0x0d1117, 1); // dark background
+                debugRendererRef.current = renderer;
+
+                const scene = new THREE.Scene();
+
+                const camera = new THREE.PerspectiveCamera(
+                  60,
+                  width / Math.max(1, height),
+                  0.1,
+                  100000
+                );
+                camera.position.set(0, 0, 200);
+                camera.lookAt(0, 0, 0);
+                debugCameraRef.current = camera;
+
+                // Debug primitives
+                scene.add(new THREE.AxesHelper(100));
+                scene.add(
+                  new THREE.Mesh(
+                    new THREE.BoxGeometry(50, 50, 50),
+                    new THREE.MeshBasicMaterial({ color: 0xff3366 })
+                  )
+                );
+
+                // Dense star field
+                const N = 2000;
+                const pos = new Float32Array(N * 3);
+                for (let i = 0; i < N; i++) {
+                  const r = 500 * Math.cbrt(Math.random());
+                  const th = Math.acos(2 * Math.random() - 1);
+                  const ph = 2 * Math.PI * Math.random();
+                  pos[3 * i + 0] = r * Math.sin(th) * Math.cos(ph);
+                  pos[3 * i + 1] = r * Math.sin(th) * Math.sin(ph);
+                  pos[3 * i + 2] = r * Math.cos(th);
+                }
+                const geo = new THREE.BufferGeometry();
+                geo.setAttribute(
+                  "position",
+                  new THREE.BufferAttribute(pos, 3)
+                );
+                const pts = new THREE.Points(
+                  geo,
+                  new THREE.PointsMaterial({
+                    size: 8,
+                    sizeAttenuation: false,
+                    color: 0xffffff,
+                    depthTest: true,
+                  })
+                );
+                pts.frustumCulled = false;
+                scene.add(pts);
+
+                // Always-visible billboard in front of camera (so you ALWAYS see something)
+                const sprite = new THREE.Sprite(
+                  new THREE.SpriteMaterial({ color: 0x00ff88 })
+                );
+                sprite.material.depthTest = false;
+                scene.add(sprite);
+                const placeSprite = () => {
+                  const dir = new THREE.Vector3();
+                  camera.getWorldDirection(dir);
+                  sprite.position
+                    .copy(camera.position)
+                    .add(dir.multiplyScalar(20));
+                };
+
+                console.log(
+                  "GL init sizes",
+                  gl.drawingBufferWidth,
+                  gl.drawingBufferHeight,
+                  "vw/vh",
+                  vw,
+                  vh,
+                  "dpr",
+                  dpr
+                );
+
+                renderer.setAnimationLoop(() => {
+                  placeSprite();
+                  renderer.render(scene, camera);
+                  gl.endFrameEXP();
+                });
+
+                return; // keep your normal path intact when DEBUG is off
+              }
+
+              rendererHandle.current = initRenderer(gl, {
+                engine,
+                maxStars,
+                maxCivs,
+                cam,
+                lookAt,
+                focusTween,
+                stickL,
+                stickR,
+                overlay,
+                threeRefs,
+                onFps,
+                rendererRef,
+              });
+
+              // After renderer+scene+camera exist, attach the real-sim stars
+              // (initRenderer should populate threeRefs.current.scene/camera)
+              // We defer to the next tick to ensure they're set.
+              setTimeout(ensureSimStars, 0);
+            }}
+          />
+        )}
 
         {/* Overlays */}
         <Vignette opacity={0.5} />


### PR DESCRIPTION
## Summary
- avoid zero-size GL buffers by waiting for non-zero layout before mounting GLView
- sync debug renderer/camera to layout and add always-visible sprite in forced debug scene

## Testing
- `npm run typecheck`
- `npx expo start -c` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a26e588b88832ea988dc6872f9da7a