### PR TITLE
fix: keep star size constant in screen space

### DIFF
--- a/src/gl/StarsMesh.ts
+++ b/src/gl/StarsMesh.ts
@@ -7,7 +7,6 @@ export function createStarsMesh(devicePixelRatio: number) {
 
   const positions = new Float32Array(N * 3);
   const colors = new Float32Array(N * 3);
-  const sizes = new Float32Array(N);
 
   for (let i = 0; i < N; i++) {
     const s = world.stars[i];
@@ -21,22 +20,19 @@ export function createStarsMesh(devicePixelRatio: number) {
     colors[i * 3 + 1] = c;
     colors[i * 3 + 2] = c;
 
-    // DPI-aware base size; PointsMaterial uses size in pixels (screen space)
-    sizes[i] = (1.0 + (s.lum - 0.7) * 3.0) * devicePixelRatio;
   }
 
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
   geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
-  geometry.setAttribute("size", new THREE.BufferAttribute(sizes, 1)); // custom attr; we’ll use sizeAttenuation instead
-
   // Use PointsMaterial (simple, fast, no custom shader).
-  // Ensure stars are actually visible on mobile GL: sizeAttenuation=true, transparent=false (solid), depthWrite=false avoids z-fighting
+  // Keep star size constant in screen space so distant stars remain visible.
+  // depthWrite=false avoids z-fighting when blending
   const material = new THREE.PointsMaterial({
     vertexColors: true,
-    size: 2.0 * devicePixelRatio, // base point size
-    sizeAttenuation: true, // appears smaller when far, larger when near
-    depthWrite: false, // additive effect
+    size: 2.0 * devicePixelRatio, // base point size in px
+    sizeAttenuation: false, // screen-space sizing, no perspective shrink
+    depthWrite: false,
   });
 
   // Optional: make them pop on dark background


### PR DESCRIPTION
## Summary
- ensure PointsMaterial uses screen-space sizing so distant stars remain visible

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7a947a09c832eb741a2b1aa9d679f