### PR TITLE
fix: allow star background to render

### DIFF
--- a/src/gl/renderer3d.ts
+++ b/src/gl/renderer3d.ts
@@ -256,7 +256,6 @@ export function initRenderer(gl: any, opts: InitOpts): RendererHandle {
   nebB.position.set(R * 0.6, -R * 0.25, R * 0.2);
   nebC.position.set(-R * 0.2, -R * 0.3, R * 0.7);
   scene.add(nebA, nebB, nebC);
-  threeRefs.current.bgStars = bgStars;
   threeRefs.current.nebulas = [nebA, nebB, nebC];
 
   // grid/axes for orientation


### PR DESCRIPTION
## Summary
- ensure background stars and nebulas render by not registering them as sim stars

## Testing
- `npm run typecheck`
- `npx expo start -c --offline`

------
https://chatgpt.com/codex/tasks/task_e_68aa29bf3890832ea10aa0d2ca676a11