### PR TITLE
fix: render sim content on load

### DIFF
--- a/src/gl/Scene.tsx
+++ b/src/gl/Scene.tsx
@@ -213,8 +213,13 @@ export const GLScene = React.forwardRef<GLSceneHandle, Props>(function GLScene(
 
     // place the camera so the real cluster is visible on boot
     const world = getWorld();
-    // Prefer sim radius if engine exposes it, else approximate from params via world builder
-    const radius = (engine as any).radius ?? 200_000;
+    // Prefer sim radius if engine exposes it; fall back to initial params/world size
+    const radius = Math.max(
+      (engine as any).radius ?? 0,
+      (engine as any).params?.radiusStart ?? 0,
+      world?.stars?.length ? (engine as any).params?.starRadius ?? 0 : 0,
+      50
+    );
     const dist = Math.max(20, radius * 2.2);
     // If the renderer has a focusPoint helper, keep using it so UI overlays/motion stay in sync
     rendererHandle.current?.focusPoint?.(0, 0, 0, dist);

--- a/src/gl/engineAdapter.ts
+++ b/src/gl/engineAdapter.ts
@@ -1,24 +1,38 @@
-import type { EngineView } from './types';
+import type { EngineView } from "./types";
 
 type MaybeArr = Float32Array | Uint8Array | Int32Array | number[] | undefined;
 const num = (a: MaybeArr, i: number, d = 0) => (a ? Number((a as any)[i] ?? d) : d);
-const pick = <T extends MaybeArr>(...c: T[]): T | undefined => { for (const x of c) if (x != null) return x; return undefined; };
-const pickNum = (...c: any[]) => { for (const x of c) if (typeof x === 'number') return x as number; return 0; };
+const pick = <T extends MaybeArr>(...c: T[]): T | undefined => {
+  for (const x of c) if (x != null) return x;
+  return undefined;
+};
+const pickNum = (...c: any[]) => {
+  for (const x of c) if (typeof x === "number") return x as number;
+  return 0;
+};
 
 function getStarAccessor(raw: any) {
   const sx = pick(raw.sx, raw.starX, raw.starsX);
   const sy = pick(raw.sy, raw.starY, raw.starsY);
   const sz = pick(raw.sz, raw.starZ, raw.starsZ);
   const sPos = pick(raw.sPos, raw.starPos, raw.starsPos, raw.starPositions);
-  let starCount = pickNum(raw.starCount, raw.starsCount);
-  if (!starCount) {
-    if (sPos && (sPos as any).length % 3 === 0) starCount = (sPos as any).length / 3;
-    else starCount = Math.min(sx?.length ?? 0, sy?.length ?? 0, sz?.length ?? 0);
+  const count = () => {
+    const declared = pickNum(raw.starCount, raw.starsCount);
+    if (declared) return declared;
+    if (sPos && (sPos as any).length % 3 === 0) return (sPos as any).length / 3;
+    return Math.min(sx?.length ?? 0, sy?.length ?? 0, sz?.length ?? 0);
+  };
+  if (sPos) {
+    return {
+      count,
+      get: (i: number) =>
+        [num(sPos, i * 3), num(sPos, i * 3 + 1), num(sPos, i * 3 + 2)] as [number, number, number],
+    };
   }
-  if (sPos && (sPos as any).length >= starCount * 3) {
-    return { starCount, get: (i: number) => [num(sPos, i * 3), num(sPos, i * 3 + 1), num(sPos, i * 3 + 2)] as [number, number, number] };
-  }
-  return { starCount, get: (i: number) => [num(sx, i), num(sy, i), num(sz, i)] as [number, number, number] };
+  return {
+    count,
+    get: (i: number) => [num(sx, i), num(sy, i), num(sz, i)] as [number, number, number],
+  };
 }
 
 function getCivAccessor(raw: any) {
@@ -28,19 +42,22 @@ function getCivAccessor(raw: any) {
   const cPos = pick(raw.cPos, raw.civPos, raw.cPositions);
   const cAlive = pick(raw.cAlive, raw.civAlive, raw.alive);
   const cStrat = pick(raw.cStrat, raw.civStrat, raw.strat);
-  const cTech  = pick(raw.cT, raw.civTech, raw.tech);
-  const cRev   = pick(raw.cRevealed, raw.civRevealed, raw.revealed);
+  const cTech = pick(raw.cT, raw.civTech, raw.tech);
+  const cRev = pick(raw.cRevealed, raw.civRevealed, raw.revealed);
 
-  let civCount = raw.civCount ?? (cPos ? (cPos as any).length / 3 : 0);
-  if (!civCount) civCount = Math.min(cx?.length ?? 0, cy?.length ?? 0, cz?.length ?? 0);
+  const count = () => {
+    const declared = raw.civCount ?? 0;
+    if (declared) return declared;
+    if (cPos) return (cPos as any).length / 3;
+    return Math.min(cx?.length ?? 0, cy?.length ?? 0, cz?.length ?? 0);
+  };
 
-  const pos =
-    cPos
-      ? (i: number) => [num(cPos, i * 3), num(cPos, i * 3 + 1), num(cPos, i * 3 + 2)] as [number, number, number]
-      : (i: number) => [num(cx, i), num(cy, i), num(cz, i)] as [number, number, number];
+  const pos = cPos
+    ? (i: number) => [num(cPos, i * 3), num(cPos, i * 3 + 1), num(cPos, i * 3 + 2)] as [number, number, number]
+    : (i: number) => [num(cx, i), num(cy, i), num(cz, i)] as [number, number, number];
 
   return {
-    civCount,
+    count,
     isAlive: (i: number) => Boolean(num(cAlive, i)),
     pos,
     strat: (i: number) => Math.floor(num(cStrat, i)),
@@ -64,8 +81,12 @@ export function adaptEngine(raw: any): EngineView {
     }
   };
   return {
-    starCount: stars.starCount,
-    civCount: civ.civCount,
+    get starCount() {
+      return stars.count();
+    },
+    get civCount() {
+      return civ.count();
+    },
     step,
     getStar: stars.get,
     isCivAlive: civ.isAlive,

--- a/src/gl/renderer3d.ts
+++ b/src/gl/renderer3d.ts
@@ -246,7 +246,8 @@ export function initRenderer(gl: any, opts: InitOpts): RendererHandle {
   threeRefs.current.raycaster = new THREE.Raycaster();
 
   // background
-  const R = ((engine as any).radius ?? 50) * 30;
+  const radiusHint = (engine as any).radius ?? (engine as any).params?.radiusStart ?? 50;
+  const R = Math.max(1, radiusHint) * 30;
   const bgStars = makeOuterStars(3000, R);
   scene.add(bgStars);
   const nebA = makeNebulaSprite(256, "#6cc3ff", 1);
@@ -260,13 +261,14 @@ export function initRenderer(gl: any, opts: InitOpts): RendererHandle {
   threeRefs.current.nebulas = [nebA, nebB, nebC];
 
   // grid/axes for orientation
+  const orientRadius = Math.max(1, radiusHint);
   const grid = new THREE.GridHelper(
-    ((engine as any).radius ?? 50) * 2,
+    orientRadius * 2,
     20,
     0x254066,
     0x15223a
   );
-  const axes = new THREE.AxesHelper(((engine as any).radius ?? 50) * 0.35);
+  const axes = new THREE.AxesHelper(orientRadius * 0.35);
   const setOpacity = (obj: THREE.Object3D, opacity: number) => {
     const mats: any[] = [];
     obj.traverse((o: any) => {


### PR DESCRIPTION
## Summary
- refresh engine star/civ counts dynamically so buffer updates actually reflect spawned content
- ensure background, grid, and initial camera focus use non-zero radius hints so the scene is visible immediately

## Perf
- negligible; count lookups are simple getters

## Screenshots
- not captured (no visual tooling available in container)

## Verification
- npm run typecheck

## Risk
- rendering (Scene, renderer3d)
- engine adapter


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226685f760832e85194e4de2164dcb)