### PR TITLE
docs: emphasize documenting implementations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,11 +210,14 @@ npx expo start -c
 
 When opening PRs or automated edits, include:
 
-1) **Summary**: User-visible changes and why.  
-2) **Perf note**: Any effect on FPS/memory.  
-3) **Screenshots** (before/after).  
-4) **Verification steps**: copy/paste commands + in-app steps.  
-5) **Risk**: surfaces touched (Scene, Engine, Overlays, State).  
+1) **Summary**: User-visible changes and why.
+   - Add a concise implementation note so future contributors understand the approach and can build on it.
+2) **Perf note**: Any effect on FPS/memory.
+3) **Screenshots** (before/after).
+4) **Verification steps**: copy/paste commands + in-app steps.
+5) **Risk**: surfaces touched (Scene, Engine, Overlays, State).
+
+Always aim to expand the repository’s knowledge: document decisions, assumptions, and new patterns so subsequent tasks have richer context to reference.
 
 Prefer **atomic PRs** (one feature/fix per branch).
 


### PR DESCRIPTION
## Summary
- add guidance in the Agent Playbook to include concise implementation notes alongside summaries
- remind contributors to document decisions and assumptions to grow repository knowledge

## Perf note
- documentation-only change; no runtime impact

## Verification steps
- not run (docs-only change)

## Risk
- documentation (AGENTS handbook)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb13e6334832e8f5be39822097a62)