### PR TITLE
Ensure home star uses consistent warm color

### DIFF
--- a/src/sim/homeSystem.ts
+++ b/src/sim/homeSystem.ts
@@ -43,11 +43,11 @@ function seededRandom(seed: number) {
   };
 }
 
-const STAR_COLORS = [
-  { temp: 3000, color: '#ffaa77', name: 'Red Dwarf' },
-  { temp: 5000, color: '#ffdd88', name: 'Yellow Star' },
-  { temp: 6000, color: '#ffffee', name: 'White Star' },
-];
+const HOME_STAR_PROFILE = {
+  temp: 5778,
+  color: '#ffd27a',
+  name: 'G-type Star',
+};
 
 const PLANET_COLORS = [
   '#8b7355', // Rocky brown
@@ -64,7 +64,7 @@ export function generateHomeSystem(seed: number = Date.now()): HomeSystem {
   const rng = seededRandom(seed);
 
   // Generate star
-  const starType = STAR_COLORS[Math.floor(rng() * STAR_COLORS.length)];
+  const starType = HOME_STAR_PROFILE;
   const star: Star = {
     id: 'home-star',
     name: 'Home Star',


### PR DESCRIPTION
## Summary
- set the generated home system star to a fixed sun-like profile so its light stays a warm yellow tone
- keep planet generation logic unchanged while still respecting seeded randomness

## Perf note
- No runtime impact; only constant data for the home star color/temperature.

## Screenshots
- not included (visual change not captured in this environment)

## Verification
- npm run typecheck

## Risk
- Surface: home system generation (star metadata)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cd8f4abd8832e987cd654f56f09b2)