### PR TITLE
Add camera-locked background starfield

### DIFF
--- a/src/gl/BackgroundStars.ts
+++ b/src/gl/BackgroundStars.ts
@@ -1,0 +1,204 @@
+// src/gl/BackgroundStars.ts
+// Procedural background starfield that always renders behind the solar system.
+// Uses a sprite-based Points cloud that follows the camera position so it feels infinitely far.
+
+import * as THREE from "three";
+
+type BackgroundStarsOptions = {
+  count?: number;
+  radius?: number;
+  seed?: number;
+  pixelRatio?: number;
+  twinkleStrength?: number;
+};
+
+export type BackgroundStarsInstance = {
+  points: THREE.Points;
+  update(camera: THREE.Camera, timeSeconds: number): void;
+};
+
+function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = t;
+    r = Math.imul(r ^ (r >>> 15), 1 | r);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function createStarSpriteTexture(size = 64) {
+  const canvas: any =
+    (typeof document !== "undefined" && document.createElement("canvas")) ||
+    null;
+
+  if (canvas) {
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      const gradient = ctx.createRadialGradient(
+        size / 2,
+        size / 2,
+        0,
+        size / 2,
+        size / 2,
+        size / 2
+      );
+      gradient.addColorStop(0, "rgba(255,255,255,1)");
+      gradient.addColorStop(0.35, "rgba(255,255,255,0.65)");
+      gradient.addColorStop(1, "rgba(255,255,255,0)");
+
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, size, size);
+
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.needsUpdate = true;
+      texture.generateMipmaps = true;
+      texture.magFilter = THREE.LinearFilter;
+      texture.minFilter = THREE.LinearMipmapLinearFilter;
+      return texture;
+    }
+  }
+
+  // Fallback path for environments without a 2D canvas: synthesize the sprite via DataTexture.
+  const data = new Uint8Array(size * size * 4);
+  const center = size / 2;
+  const radius = size / 2;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dx = x - center;
+      const dy = y - center;
+      const d = Math.sqrt(dx * dx + dy * dy) / radius;
+      const falloff = Math.max(0, 1 - d);
+      const alpha = Math.pow(falloff, 1.6);
+      const i = (y * size + x) * 4;
+      data[i + 0] = 255;
+      data[i + 1] = 255;
+      data[i + 2] = 255;
+      data[i + 3] = Math.floor(255 * alpha);
+    }
+  }
+  const texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+  texture.needsUpdate = true;
+  texture.generateMipmaps = true;
+  texture.magFilter = THREE.LinearFilter;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  return texture;
+}
+
+export function createBackgroundStars(
+  opts: BackgroundStarsOptions = {}
+): BackgroundStarsInstance {
+  const {
+    count = 4500,
+    radius = 12000,
+    seed = 7,
+    pixelRatio = 1,
+    twinkleStrength = 0.08,
+  } = opts;
+
+  const rng = mulberry32(seed);
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+  const sizes = new Float32Array(count);
+  const twinklePhase = new Float32Array(count);
+
+  for (let i = 0; i < count; i++) {
+    // Uniform distribution on a spherical shell (no clustering at the poles).
+    const u = rng();
+    const v = rng();
+    const theta = 2 * Math.PI * u;
+    const cosPhi = 2 * v - 1;
+    const sinPhi = Math.sqrt(Math.max(0, 1 - cosPhi * cosPhi));
+    const r = radius * (0.92 + 0.08 * rng());
+
+    positions[i * 3 + 0] = r * sinPhi * Math.cos(theta);
+    positions[i * 3 + 1] = r * cosPhi;
+    positions[i * 3 + 2] = r * sinPhi * Math.sin(theta);
+
+    // Subtle color temperature variation (cool blue to warm yellow) with brightness baked in.
+    const temp = rng() * 2 - 1; // -1..1
+    const baseLum = 0.7 + Math.pow(rng(), 2.5) * 0.6;
+    const warm = Math.max(0, temp);
+    const cool = Math.max(0, -temp);
+    const rCol = Math.min(1, baseLum + warm * 0.18);
+    const gCol = Math.min(1, baseLum - warm * 0.05 + cool * 0.05);
+    const bCol = Math.min(1, baseLum + cool * 0.25);
+    colors[i * 3 + 0] = rCol;
+    colors[i * 3 + 1] = gCol;
+    colors[i * 3 + 2] = bCol;
+
+    // Many small stars, a few bright ones.
+    const magnitude = Math.pow(rng(), 2.8);
+    sizes[i] = 1.2 + magnitude * 3.2;
+
+    twinklePhase[i] = rng() * Math.PI * 2;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  geometry.setAttribute("aSize", new THREE.BufferAttribute(sizes, 1));
+  geometry.setAttribute("aTwinkle", new THREE.BufferAttribute(twinklePhase, 1));
+  geometry.computeBoundingSphere();
+
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      uTexture: { value: createStarSpriteTexture() },
+      uPixelRatio: { value: pixelRatio },
+      uTime: { value: 0 },
+      uTwinkleStrength: { value: twinkleStrength },
+    },
+    vertexShader: `
+      uniform float uPixelRatio;
+      attribute float aSize;
+      attribute float aTwinkle;
+      varying float vTwinkle;
+      varying vec3 vColor;
+      void main() {
+        vColor = color;
+        vTwinkle = aTwinkle;
+        vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+        // Keep roughly constant on screen (no size attenuation) for "infinitely far" feel.
+        gl_PointSize = aSize * uPixelRatio;
+        gl_Position = projectionMatrix * mvPosition;
+      }
+    `,
+    fragmentShader: `
+      precision mediump float;
+      uniform sampler2D uTexture;
+      uniform float uTime;
+      uniform float uTwinkleStrength;
+      varying float vTwinkle;
+      varying vec3 vColor;
+      void main() {
+        vec4 sprite = texture2D(uTexture, gl_PointCoord);
+        float twinkle = 1.0 + uTwinkleStrength * sin(uTime + vTwinkle);
+        float alpha = sprite.a * twinkle;
+        if (alpha < 0.01) discard;
+        gl_FragColor = vec4(vColor * twinkle, 1.0) * vec4(sprite.rgb, alpha);
+      }
+    `,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    depthTest: false,
+    transparent: true,
+    vertexColors: true,
+  });
+  material.toneMapped = false;
+
+  const points = new THREE.Points(geometry, material);
+  points.frustumCulled = false;
+  points.renderOrder = -1000; // ensure background draws before the solar system without touching depth
+
+  return {
+    points,
+    update(camera, timeSeconds) {
+      points.position.copy(camera.position); // lock translation to camera → no parallax
+      (material.uniforms.uTime as THREE.IUniform).value = timeSeconds;
+    },
+  };
+}
+

--- a/src/gl/Scene.tsx
+++ b/src/gl/Scene.tsx
@@ -19,8 +19,6 @@ import { pickStrongest, pickFrontier, pickNearest, pickDensest } from "./poi";
 import { createCameraController } from "./cameraController";
 import { initRenderer } from "./renderer3d";
 import type { CameraState, RaycastRefs } from "./types";
-import { createStarsMesh } from "./StarsMesh";
-import { getWorld } from "../sim/world";
 
 // Public API for parent components
 export type GLSceneHandle = {
@@ -185,41 +183,6 @@ export const GLScene = React.forwardRef<GLSceneHandle, Props>(function GLScene(
     lookAt.current.set(0, 0, 0);
   }, [engine]);
 
-  // NEW: ensure stars are created from the actual sim and added to the scene
-  const ensureSimStars = useCallback(() => {
-    const { scene, camera } = threeRefs.current;
-    if (!scene || !camera) return;
-
-    // avoid duplicates on hot reloads
-    if (
-      threeRefs.current.bgStars &&
-      scene.children.includes(threeRefs.current.bgStars)
-    ) {
-      return;
-    }
-
-    // build (or get) the real world, then build a static Points cloud
-    const starsPoints = createStarsMesh(PixelRatio.get());
-    threeRefs.current.bgStars = starsPoints;
-    scene.add(starsPoints);
-
-    // sane camera + far clip for a big cluster
-    camera.near = Math.min(camera.near, 0.1);
-    camera.far = Math.max(camera.far, 1e9);
-    camera.updateProjectionMatrix();
-
-    // optional: set clear color to deep space
-    rendererRef.current?.renderer.setClearColor(0x000006, 1);
-
-    // place the camera so the real cluster is visible on boot
-    const world = getWorld();
-    // Prefer sim radius if engine exposes it, else approximate from params via world builder
-    const radius = (engine as any).radius ?? 200_000;
-    const dist = Math.max(20, radius * 2.2);
-    // If the renderer has a focusPoint helper, keep using it so UI overlays/motion stay in sync
-    rendererHandle.current?.focusPoint?.(0, 0, 0, dist);
-  }, [engine]);
-
   return (
     <GestureDetector gesture={gesture}>
       <View style={{ flex: 1, position: "relative" }} onLayout={onLayout}>
@@ -240,11 +203,6 @@ export const GLScene = React.forwardRef<GLSceneHandle, Props>(function GLScene(
               onFps,
               rendererRef,
             });
-
-            // After renderer+scene+camera exist, attach the real-sim stars
-            // (initRenderer should populate threeRefs.current.scene/camera)
-            // We defer to the next tick to ensure they're set.
-            setTimeout(ensureSimStars, 0);
           }}
         />
 

--- a/src/gl/renderer3d.ts
+++ b/src/gl/renderer3d.ts
@@ -4,9 +4,10 @@ import * as THREE from "three";
 
 import { adaptEngine, sampleCivs } from "./engineAdapter";
 import type { CameraState, RaycastRefs } from "./types";
+import { createBackgroundStars } from "./BackgroundStars";
 
 // ---------- Tunables ----------
-const CAMERA_FAR = 5000;
+const CAMERA_FAR = 20000;
 const STAR_U_SCALE = 220.0; // bigger point size at distance
 const STAR_U_MAX = 24.0; // px * pixelRatio
 const CIV_U_MAX = 28.0; // px * pixelRatio
@@ -49,38 +50,6 @@ void main(){
   gl_FragColor = vec4(vColor, a);
 }`;
 
-// ---------- background: parallax stars + soft nebula ----------
-function makeOuterStars(n: number, R: number) {
-  const g = new THREE.BufferGeometry();
-  const p = new Float32Array(n * 3);
-  const c = new Float32Array(n * 3);
-  for (let i = 0; i < n; i++) {
-    const u = Math.random(),
-      v = Math.random();
-    const theta = 2 * Math.PI * u;
-    const cosPhi = 2 * v - 1;
-    const sinPhi = Math.sqrt(Math.max(0, 1 - cosPhi * cosPhi));
-    const r = R * (0.94 + 0.12 * Math.random());
-    p[i * 3 + 0] = r * sinPhi * Math.cos(theta);
-    p[i * 3 + 1] = r * cosPhi * 0.6;
-    p[i * 3 + 2] = r * sinPhi * Math.sin(theta);
-    const t = Math.random();
-    c[i * 3 + 0] = 0.75 + 0.25 * t * 0.2;
-    c[i * 3 + 1] = 0.82 + 0.18 * t;
-    c[i * 3 + 2] = 0.95 + 0.05 * Math.random();
-  }
-  g.setAttribute("position", new THREE.BufferAttribute(p, 3));
-  g.setAttribute("color", new THREE.BufferAttribute(c, 3));
-  const m = new THREE.PointsMaterial({
-    size: 2,
-    sizeAttenuation: true,
-    vertexColors: true,
-    transparent: true,
-  });
-  const mesh = new THREE.Points(g, m);
-  mesh.frustumCulled = false;
-  return mesh;
-}
 function makeNebulaSprite(
   size: number,
   tint: THREE.ColorRepresentation,
@@ -114,6 +83,7 @@ function makeNebulaSprite(
     transparent: true,
     blending: THREE.AdditiveBlending,
     depthWrite: false,
+    depthTest: false,
   });
   const sprite = new THREE.Sprite(mat);
   sprite.scale.setScalar(R * 8);
@@ -245,19 +215,33 @@ export function initRenderer(gl: any, opts: InitOpts): RendererHandle {
   threeRefs.current.scene = scene;
   threeRefs.current.raycaster = new THREE.Raycaster();
 
-  // background
-  const R = ((engine as any).radius ?? 50) * 30;
-  const bgStars = makeOuterStars(3000, R);
-  scene.add(bgStars);
+  // background: sprite-based stars locked to the camera for an infinite sky
+  const bgRadius = Math.max(8000, ((engine as any).radius ?? 50) * 120);
+  const backgroundStars = createBackgroundStars({
+    count: 4800,
+    radius: bgRadius,
+    pixelRatio: pr,
+    seed: 11,
+    twinkleStrength: 0.06,
+  });
+  scene.add(backgroundStars.points);
+  threeRefs.current.bgStars = backgroundStars.points;
+
   const nebA = makeNebulaSprite(256, "#6cc3ff", 1);
   const nebB = makeNebulaSprite(256, "#f48fb1", 2);
   const nebC = makeNebulaSprite(256, "#88f7c5", 3);
-  nebA.position.set(-R * 0.4, R * 0.15, -R * 0.6);
-  nebB.position.set(R * 0.6, -R * 0.25, R * 0.2);
-  nebC.position.set(-R * 0.2, -R * 0.3, R * 0.7);
+  nebA.position.set(-bgRadius * 0.25, bgRadius * 0.12, -bgRadius * 0.5);
+  nebB.position.set(bgRadius * 0.4, -bgRadius * 0.2, bgRadius * 0.18);
+  nebC.position.set(-bgRadius * 0.18, -bgRadius * 0.28, bgRadius * 0.6);
+  nebA.renderOrder = -900;
+  nebB.renderOrder = -900;
+  nebC.renderOrder = -900;
   scene.add(nebA, nebB, nebC);
-  threeRefs.current.bgStars = bgStars;
   threeRefs.current.nebulas = [nebA, nebB, nebC];
+
+  const maxViewDistance = Math.max(CAMERA_FAR, bgRadius * 1.2);
+  camera.far = maxViewDistance * 1.1;
+  camera.updateProjectionMatrix();
 
   // grid/axes for orientation
   const grid = new THREE.GridHelper(
@@ -468,7 +452,7 @@ export function initRenderer(gl: any, opts: InitOpts): RendererHandle {
     );
     cam.current.dist = Math.max(
       5,
-      Math.min(CAMERA_FAR, cam.current.dist - stickR.current.y * dt * 40)
+      Math.min(maxViewDistance, cam.current.dist - stickR.current.y * dt * 40)
     );
 
     const { yaw, pitch, dist } = cam.current;
@@ -479,6 +463,9 @@ export function initRenderer(gl: any, opts: InitOpts): RendererHandle {
     camera.updateProjectionMatrix();
     camera.position.set(cx, cy, cz);
     camera.lookAt(lookAt.current);
+
+    // Keep the background sphere centered on the camera so stars stay "infinitely" far.
+    backgroundStars.update(camera, now / 1000);
 
     if (E.starCount > lastStarCount) {
       for (let i = lastStarCount; i < E.starCount; i++) {


### PR DESCRIPTION
## Summary
- add a reusable BackgroundStars module that builds a soft sprite texture, distributes stars on a distant shell, and adds subtle color/twinkle
- integrate the camera-locked starfield into the renderer with disabled depth, low render order, and updated far plane so stars always sit behind the solar system
- retune nebula layering to keep overlays behind the main scene while preserving the existing grid/axes helpers

## Performance
- ~4.8k additive point sprites with no depth writes; minimal GPU cost expected on mobile

## Screenshots
- not included (GL scene)

## Verification
- npm run typecheck

## Risk
- Touches renderer background/camera setup; regressions could affect scene framing or background draw order

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941bcd205e4832e8f19963f4356f56f)